### PR TITLE
Fixed bug when removing extra empty lines

### DIFF
--- a/MCCRegionSelector/MainWindow.xaml.cs
+++ b/MCCRegionSelector/MainWindow.xaml.cs
@@ -76,7 +76,7 @@ namespace MCCRegionSelector
 
         private string ConfigureHostsFile(string hostsFile)
         {
-            var hostsToAddSB = new StringBuilder("\n");
+            var hostsToAddSB = new StringBuilder(Environment.NewLine);
 
             foreach (ListBoxItem item in regionsListBox.Items)
             {
@@ -90,7 +90,7 @@ namespace MCCRegionSelector
                     foreach (var host in hosts)
                     {
                         if (hostsFile.Contains(host))
-                            hostsFile = hostsFile.Replace($"\n{host}", string.Empty);
+                            hostsFile = hostsFile.Replace(Environment.NewLine + host, string.Empty);
                     }
                 }
                 // Add new.
@@ -108,7 +108,7 @@ namespace MCCRegionSelector
 
             // Removes the extra empty lines.
             hostsFile = hostsFile
-                .Replace("\r\n\r\n", string.Empty)
+                .Replace("\r\n\r\n", "\r\n")
                 .Replace("\r\r", string.Empty)
                 .Replace("\n\n", string.Empty);
 


### PR DESCRIPTION
To reproduce bug:

1. Start with a hosts file that ends with a newline that's represented by CRLF; I used Notepad++ to show the carriage return (CR) and line feed (LF) symbols.
2. Start application and choose any region, such as "East Japan" and apply.
2.1 The file now contains just a CR after the typical "localhost" row instead of CRLF (or for that matter the typical LF (= \n)).
3. Select any region, such as "West Japan" and apply.
3.1 Now the file has just a CR after the last row.
4. Choose "Select All" and "Apply".
5. Notice that the first written line by the application is still left in the hosts file, when this too should have been removed.

If you begin with a hosts file that _doesn't_ contain a newline at all at the end, you can run the program once without any problem but after step 4 above, the last line is a CRLF, and therefore running the steps again from the beginning will give rise to the bug anyway.

This is due to a mismatch between the ```hostsFile.Replace``` method call input parameter, which looks for LF followed by the host and what the file actually contains, which could be just a CR. I've changed the new line to ```Environment.NewLine``` to create a more consistent hosts file, as we therefore only need to check for CRLF and not either just CR or LF.

Moreover, when cleaning up empty lines, a replace of CRLFCRLF with empty string also result in the removal of one to much line if the hosts file already contains a CRLF as the last content of the file.

Consider the new hosts content (before cleaning up empty lines) as below. 

```
127.0.0.1 localhost{CR}{LF}
{CR}{LF}
0.0.0.0 pfmsqosprod.centralus.cloudapp.azure.com
```

When doing ```Replace("\r\n\r\n", string.Empty)```, this results in:

```
127.0.0.1 localhost0.0.0.0 pfmsqosprod.centralus.cloudapp.azure.com
```

Simply changing this to ```Replace("\r\n\r\n", "\r\n")``` gives the correct behavior. The code has been tested and works for both hosts files ending with a CRLF and those that doesn't. It's possible that replacing ```\r\r``` and ```\n\n``` with empty string should be changed to ```\r``` and ```\n``` respectively, but I haven't tested that.